### PR TITLE
Clean up all READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ You do not need to complete all of these adventures. Instead, please pick the
 ones that are more interesting or relevant to your needs.
 
 Regardless of which adventure you pick, you will migrate an old version of the
-[spring-petclinic](https://github.com/spring-projects/spring-petclinic/)
+[Spring PetClinic](https://github.com/spring-projects/spring-petclinic/)
 repository to Spring Boot 3.
 
 ## Introduction

--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ git clone https://github.com/moderneinc/springboot-migration-workshop
 
 ## Adventures
 
-* [Maven Plugin Adventure](https://github.com/moderneinc/springboot-migration-workshop/tree/main/maven-plugin-adventure)
+* [Maven Plugin Adventure](./maven-plugin-adventure)
 
-* [Gradle Plugin Adventure](https://github.com/moderneinc/springboot-migration-workshop/tree/main/gradle-plugin-adventure)
+* [Gradle Plugin Adventure](./gradle-plugin-adventure)
 
-* [Spring Boot Migrator Adventure](https://github.com/moderneinc/springboot-migration-workshop/tree/main/spring-boot-migrator-adventure)
+* [Spring Boot Migrator Adventure](./spring-boot-migrator-adventure)
  
-* [Spring Tools Adventure](https://github.com/moderneinc/springboot-migration-workshop/tree/main/spring-tools-adventure)
+* [Spring Tools Adventure](./spring-tools-adventure)
 
-* [Moderne Platform Adventure](https://github.com/moderneinc/springboot-migration-workshop/tree/main/moderne-platform-adventure)
+* [Moderne Platform Adventure](./moderne-platform-adventure)
 
-* [Moderne CLI Adventure](https://github.com/moderneinc/springboot-migration-workshop/tree/main/moderne-cli-adventure)
+* [Moderne CLI Adventure](./moderne-cli-adventure)

--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
 # Springboot Migration Workshop
 
-This is a collection of adventures for automatic remediation based on OpenRewrite.
-Each adventure represent a valid option to apply a SpringBoot migration.
-It is not expected that you complete all our adventures, but enjoy with the ones 
-that are interesting to you because of the technologies that are applied. 
+In this repository, you'll find a variety of "adventures" that demonstrate the
+different ways you can automatically migrate or upgrade an application to Spring
+Boot 3. The core technology behind each of these adventures is
+[OpenRewrite](https://github.com/openrewrite/rewrite).
 
-For all the adventures we are going to use different solutions to migrate 
-an old version of the [spring-petclinic](https://github.com/spring-projects/spring-petclinic/)
-to SpringBoot 3.
+You do not need to complete all of these adventures. Instead, please pick the
+ones that are more interesting or relevant to your needs.
+
+Regardless of which adventure you pick, you will migrate an old version of the
+[spring-petclinic](https://github.com/spring-projects/spring-petclinic/)
+repository to Spring Boot 3.
 
 ## Introduction
 
@@ -15,24 +18,22 @@ to SpringBoot 3.
 
 ## Requirements
 
-In complete our adventures, you will need some basic Spring and Git knowlege and:
+To complete our adventures, you will need:
 
-* Java 17 and Java 8
-
-* IDE of your choice, but Visual Studio Code for the Spring Tools Adventure. 
-
-* GitHub account
+* Some basic Spring and Git knowledge and:
+* To be familiar with Java 8 and Java 17
+* A GitHub account
+* An IDE of your choice (although we recommend using [Visual Studio Code](https://code.visualstudio.com/) for the Spring Tools Adventure)
 
 ## Getting started
 
-Clone this Git repository and follow the desired adventures. 
+Clone this Git repository and follow the desired adventures.
+
 ```
 git clone https://github.com/moderneinc/springboot-migration-workshop
 ```
 
 ## Adventures
-
-We recommend to follow the adventures in the described order, but it is just a recommendation, not a requirement.
 
 * [Maven Plugin Adventure](https://github.com/moderneinc/springboot-migration-workshop/tree/main/maven-plugin-adventure)
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ repository to Spring Boot 3.
 
 To complete our adventures, you will need:
 
-* Some basic Spring and Git knowledge and:
+* Some basic Spring and Git knowledge
 * To be familiar with Java 8 and Java 17
 * A GitHub account
 * An IDE of your choice (although we recommend using [Visual Studio Code](https://code.visualstudio.com/) for the Spring Tools Adventure)
@@ -29,7 +29,7 @@ To complete our adventures, you will need:
 
 Clone this Git repository and follow the desired adventures.
 
-```
+```shell
 git clone https://github.com/moderneinc/springboot-migration-workshop
 ```
 

--- a/gradle-plugin-adventure/README.md
+++ b/gradle-plugin-adventure/README.md
@@ -1,106 +1,128 @@
 # Gradle Plugin Adventure
 
-In this adventure we are going to see how we can migrate an old version of
-the spring-petclinic repository that was using Spring Boot 2 to Spring Boot 3.
+In this adventure, you will migrate an old version of the
+[spring-petclinic](https://github.com/spring-projects/spring-petclinic/)
+repository (that uses Spring Boot 2) to Spring Boot 3.
 
-OpenRewrite recipes are lego blocks and therefore this process consists of multiple
-steps that are invisible for you:
+If you were migrating this by hand, you would need to do a variety of things
+such as:
 
-- Migrate to Spring Boot 2.7
-- Migrate to Java 17
-- Migrate to Jakarta EE 9
-- Migrate to Spring Security 6.0
-- Migrate to Spring Cloud 2022
-...
+* Migrating to Spring Boot 2.7
+* Migrating to Java 17
+* Migrating to Jakarata EE 9
+* Migrating to Spring Security 6.0
+* Migrating to Spring Cloud 2022
+* ... 
 
-Therefore, you only need to apply a single [Migrate to Spring Boot 3.0](https://docs.openrewrite.org/recipes/java/spring/boot3/upgradespringboot_3_0) 
-adding the OpenRewrite's plug-in to your project and configuring the recipe.
+Fortunately, [OpenRewrite](https://docs.openrewrite.org/) has a
+[recipe](https://docs.openrewrite.org/concepts-explanations/recipes) that takes
+care of all of these pieces for you. Because of that, you only need to add the
+OpenRewrite plugin to your project and run a single [Migrate to Spring Boot
+3.0](https://docs.openrewrite.org/recipes/java/spring/boot3/upgradespringboot_3_0)
+recipe.
 
-Optionally, if you have time, we recommend to play with one of the most important recipes in OpenRewrite to fix static code analysis issues in an old 
-repository.
+Let's walk through how to do that.
 
 ## Prepare your environment
 
-1. Clone the repository `https://github.com/spring-projects/spring-petclinic`
+1. Clone the [Spring PetClinic repository](https://github.com/spring-projects/spring-petclinic):
 
-```
+```shell
 git clone https://github.com/spring-projects/spring-petclinic
 ```
 
-2. Checkout the last commit in Spring Boot 2.0
+2. Check out the last Spring Boot 2.0 commit:
 
-```
+```shell
 git checkout 9ecdc1111e3da388a750ace41a125287d9620534
 ```
-3. Test you can build it
 
-```
+3. Make sure it runs on your machine:
+
+```shell
 ./gradlew build -x test
-``` 
+```
 
 ## Migrate to SpringBoot 3 with OpenRewrite
 
-OpenRewrite can be configured in the `build.gradle` file or as an additional `init.gradle` [see how 
-here](https://docs.openrewrite.org/running-recipes/running-rewrite-on-a-gradle-project-without-modifying-the-build)
-file without having to edit any previous build configuration. 
+OpenRewrite can be configured in your `build.gradle` file or as an additional
+`init.gradle` script without having to edit any previous build configuration
+([see how
+here](https://docs.openrewrite.org/running-recipes/running-rewrite-on-a-gradle-project-without-modifying-the-build)). 
 
-1. For simplicity, copy the `init.gradle` file that is in this folder, which already contains the Spring Boot
-recipe configured.
+1. For simplicity, we've included an [init.gradle](./init.gradle) file in this
+   folder that contains the Spring Boot migration recipe as well as the
+   OpenRewrite dependencies. Please copy [this file](./init.gradle) to the
+   Spring PetClinic repository you have checked out locally.
 
-```
-cp init.gradle spring-petclinic/init.gradle
-```
+2. With that file copied over, if you run `rewriteRun`, you will apply the
+   migration recipe:
 
-2. Run OpenRewrite
-
-```
+```shell
 ./gradlew --info --init-script init.gradle rewriteRun
 ```
 
-3. Review the changes with `git diff`
+3. You can then review the changes by running `git diff`. 
 
-## Fix Static Code Analysis Issues
+## (Optional) Fix Static Code Analysis Issues
 
-If you are interested to play with more recipes, we recommend to play with one of the most populare OpenRewrite recipes: ([static code analysis recipe](https://docs.openrewrite.org/recipes/java/cleanup/commonstaticanalysis)), which is composed by more than 50 other recipes. In this case, we are going to use a different 
-active Gradle repository that shows a wide variety of errors. The selected repository is the [Netflix Testing Framework]( 
-https://github.com/Netflix/q)
+If you have time, we recommend trying out one of the most important recipes in
+OpenRewrite: [common static
+analysis](https://docs.openrewrite.org/recipes/java/cleanup/commonstaticanalysis).
+This recipe is composed of 50+ recipes that find and fix common mistakes people
+make.
 
-1. Clone the repository 
+To demonstrate this recipe, we'll use a different Gradle repository that has a
+variety of errors that need to be fixed.
 
-```
+1. Clone the [Netflix Testing Framework](https://github.com/Netflix/q)
+   repository:
+
+```shell
 git clone https://github.com/Netflix/q
 ```
 
-2. For this repository, you need to switch to Java 8 to properly build it. So, you might need to download Java 8 and update your `JAVA_HOME` 
-environment variable.
+2. Switch to Java 8 so you can properly build this repository. You might need to
+   download Java 8 and update your `JAVA_HOME` environment variable. If you are
+   on a Unix-based system, we recommend using [SDKMan](https://sdkman.io/):
 
+```shell
+sdk install java 8.0.372-tem
+sdk use java 8.0.372-tem
 ```
+
+  * If you aren't on a Unix-based system or you don't want to install SDKMan,
+    you'll need to install Java 8 and run something like:
+
+```shell
 export JAVA_HOME=REPLACE_FOR_LOCATION_OF_JAVA_8
 ```
 
-3. Test that you can build it
+3. With the right version of Java installed, test that you can build it:
 
-```
-cd q
+```shell
 ./gradlew build -x test
 ```
 
-4. Apply the patch that is in this directory to the build.gradle file. This will automatically configure the rewrite Gradle plugin in the repository for you. We recommend to look at the differences to understand how it is configured.
+4. Copy and apply the [patch](./configure-build.patch) that is in this directory
+   to the `build.gradle` file. This will automatically configure the rewrite
+   Gradle plugin in the repository for you. We recommend that you look at the
+   differences to understand how it is configured:
 
-```
+```shell
+// Copy the file to the q repository first
+
 git apply configure-build.patch
 ```
 
-5. Run OpenRewrite
+5. With the patch applied, you can now run OpenRewrite:
 
-```
+```shell
 ./gradlew rewriteRun
 ```
 
-6. Look at the automatic changes we made
+6. Check out all of the changes that were made by running: 
 
-```
+```shell
 git diff
 ```
-
-

--- a/gradle-plugin-adventure/README.md
+++ b/gradle-plugin-adventure/README.md
@@ -1,7 +1,7 @@
 # Gradle Plugin Adventure
 
 In this adventure, you will migrate an old version of the
-[spring-petclinic](https://github.com/spring-projects/spring-petclinic/)
+[Spring PetClinic](https://github.com/spring-projects/spring-petclinic/)
 repository (that uses Spring Boot 2) to Spring Boot 3.
 
 If you were migrating this by hand, you would need to do a variety of things

--- a/maven-plugin-adventure/README.md
+++ b/maven-plugin-adventure/README.md
@@ -1,7 +1,7 @@
 # Maven Plugin Adventure
 
 In this adventure, you will migrate an old version of the
-[spring-petclinic](https://github.com/spring-projects/spring-petclinic/)
+[Spring PetClinic](https://github.com/spring-projects/spring-petclinic/)
 repository (that uses Spring Boot 2) to Spring Boot 3.
 
 If you were migrating this by hand, you would need to do a variety of things

--- a/maven-plugin-adventure/README.md
+++ b/maven-plugin-adventure/README.md
@@ -1,45 +1,60 @@
 # Maven Plugin Adventure
 
-In this adventure we are going to see how to use open rewrite in a Maven project and run a recipe to migrate to Spring Boot 3. OpenRewrite recipes are lego blocks and therefore this process consists of multiple steps that are invisible for you:
+In this adventure, you will migrate an old version of the
+[spring-petclinic](https://github.com/spring-projects/spring-petclinic/)
+repository (that uses Spring Boot 2) to Spring Boot 3.
 
-- Migrate to Spring Boot 2.7
-- Migrate to Java 17
-- Migrate to Jakarta EE 9
-- Migrate to Spring Security 6.0
-- Migrate to Spring Cloud 2022 ...
+If you were migrating this by hand, you would need to do a variety of things
+such as:
 
-Therefore, you only need to apply a single [Migrate to Spring Boot 3.0](https://docs.openrewrite.org/recipes/java/spring/boot3/upgradespringboot_3_0) adding the 
-OpenRewrite's plug-in to your project and configuring the recipe.
+* Migrating to Spring Boot 2.7
+* Migrating to Java 17
+* Migrating to Jakarata EE 9
+* Migrating to Spring Security 6.0
+* Migrating to Spring Cloud 2022
+* ... 
 
-Optionally, if you have time, you can also play with another of the most important recipes that fixes lots of static code analysis issues in a very old repository.
+Fortunately, [OpenRewrite](https://docs.openrewrite.org/) has a
+[recipe](https://docs.openrewrite.org/concepts-explanations/recipes) that takes
+care of all of these pieces for you. Because of that, you only need to add the
+OpenRewrite plugin to your project and run a single 
+[Migrate to Spring Boot 3.0](https://docs.openrewrite.org/recipes/java/spring/boot3/upgradespringboot_3_0)
+recipe.
+
+Let's walk through how to do that.
 
 ## Prepare your environment
 
-1. Clone the repository `https://github.com/spring-projects/spring-petclinic`
+1. Clone the [Spring PetClinic
+   repository](https://github.com/spring-projects/spring-petclinic):
 
-```
+```shell
 git clone https://github.com/spring-projects/spring-petclinic
 ```
 
-2. Checkout the last commit in Spring Boot 2.0
+2. Check out the last Spring Boot 2.0 commit:
 
-```
-cd spring-petclinic
+```shell
 git checkout 9ecdc1111e3da388a750ace41a125287d9620534
 ```
-3. Test you can build it
 
-```
+3. Make sure it runs on your machine:
+
+```shell
 ./mvnw package -DskipTests
 ``` 
 
 ## Migrate to SpringBoot 3 with OpenRewrite
 
-### Option 1: Updating the pom.xml
+For Maven projects, you can choose to update the `pom.xml` to add the
+OpenRewrite dependencies or you can run a more complex command in the command
+line that includes all of the information needed to run the recipe.
 
-In this case, one way is to modify the `pom.xml` file and add the following information:
+### Option 1: Update the pom.xml
 
-```
+Modify the `pom.xml` file and add the following information:
+
+```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <project>
     ...
@@ -66,52 +81,69 @@ In this case, one way is to modify the `pom.xml` file and add the following info
     </build>
 </project>
 ```
-The only thing you need to run open-rewrite is: 
 
-```
+Once you've done that, you can run the Upgrade Spring Boot 3.0 recipe by running
+this command:
+
+```shell
  ./mvnw -U org.openrewrite.maven:rewrite-maven-plugin:run
 ```
-### Option 2: Without requiring to update the pom.xml
 
-You can also run a recipe, in this case the `UpgradeSpringBoot_3_0` recipe without editing the `pom.xml` file using the following Maven command:
+You can then compare the results by running:
 
-```
-./mvnw -U org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.activeRecipes=org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_0 -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-spring:4.36.0
-```
-
-Now, you can compare the results by simply running 
-
-```
+```shell
 git diff
 ```
 
-## Fix Static Code Analysis issues
+### Option 2: Use the command line
 
-In this case, for demo purposes, we are going to use the [Spring WS](https://github.com/spring-projects/spring-ws)
-repository. This is an existing Spring repository that it is good to see what kind of static 
-code analysis issues can be fixed. 
+You can run a recipe without editing the `pom.xml` file by including all of the
+details in the command line. Below is the command for running the
+`UpgradeSpringBoot_3_0` recipe:
 
-The [static code analysis recipe](https://docs.openrewrite.org/recipes/java/cleanup/commonstaticanalysis)
-consists of more than 50 types of coding style issues that are automatically fixed with OpenRewrite.
-
-1. Clone the spring-ws repository
-
+```shell
+./mvnw -U org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.activeRecipes=org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_0 -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-spring:4.36.0
 ```
+
+You can then compare the results by running:
+
+```shell
+git diff
+```
+
+## (Optional) Fix Static Code Analysis Issues
+
+If you have time, we recommend trying out one of the most important recipes in
+OpenRewrite: [common static analysis](https://docs.openrewrite.org/recipes/java/cleanup/commonstaticanalysis).
+This recipe is composed of 50+ recipes that find and fix common mistakes people
+make.
+
+To demonstrate this recipe, we'll use a different Maven repository that has a
+variety of errors that need to be fixed.
+
+1. Clone the [Spring WS](https://github.com/spring-projects/spring-ws)
+   repository:
+
+```shell
 git clone https://github.com/spring-projects/spring-ws
 ```
 
-2. Test you can build it
+2. Test that you can build it:
 
-```
+```shell
 cd spring-ws
 ./mvnw package -DskipTests
 ```
 
-3. Run OpenRewrite. The only thing you need to run open-rewrite is
+3. Run the common static analysis recipe:
 
-```
- ./mvnw -U org.openrewrite.maven:rewrite-maven-plugin:run \
+```shell
+./mvnw -U org.openrewrite.maven:rewrite-maven-plugin:run \
   -Drewrite.activeRecipes=org.openrewrite.java.cleanup.CommonStaticAnalysis
 ```
 
+4. Check out all of the changes that were made by running: 
 
+```shell
+git diff
+```

--- a/moderne-cli-adventure/README.md
+++ b/moderne-cli-adventure/README.md
@@ -1,82 +1,96 @@
-# Moderne CLI Adventure
+# Moderne CLI adventure Adventure
 
-In this session we are going to use a free Moderne CLI that allows to 
-run OpenRewrite recipes without requiring to configure any build plugins
-and therefore support other programming languages and build tools that 
-are not for Java developers. In this adventure, we suggest two exercises:
+In this adventure, you will use the [Moderne
+CLI](https://docs.moderne.io/moderne-cli/cli-intro), a free tool that allows
+developers to run OpenRewrite recipes without configuring any build plugin, to
+migrate a repository from Spring Boot 2 to Spring Boot 3.
 
-- Migrate to Spring Boot 3 using the CLI.
-- Publish a new OSS repository into the Moderne Platform. 
+Afterwards, you'll use the CLI to publish your own OSS repository to the Moderne
+platform so that you can run recipes on it without having to build it over and
+over.
 
 ## Prepare your environment
 
-1. Download the CLI. To do so, download the CLI from `https://public.moderne.io`
+1. Download the Moderne CLI by going to
+   [https://public.moderne.io](https://public.moderne.io), clicking on the `?`
+   in the top right corner, and selecting `Moderne CLI` from the menu:
 
 ![context menu](assets/cli-download.png)
 
-2. Create a Moderne Access Token from `https://public.moderne.io/settings/access-token`
-and store it in your local file system.
+2. Create a Moderne Access Token by going to
+   [https://public.moderne.io/settings/access-token](https://public.moderne.io/settings/access-token).
+   Once there, enter a name for the token and press `generate`.
 
-```
-echo "YOUR_ACCESS_TOKEN" > $HOME/.moderne/token.txt
+3. Store the token in your local file system so it can be used by the CLI:
+
+```shell
+mkdir -p ~/.moderne && echo "mat-YOUR_TOKEN_HERE" > ~/.moderne/token.txt
 ```
 
-3. Clone the repository `https://github.com/spring-projects/spring-petclinic`
+4. Clone the [Spring PetClinic
+   repository](https://github.com/spring-projects/spring-petclinic) to your
+   machine:
 
-```
+```shell
 git clone https://github.com/spring-projects/spring-petclinic
 ```
 
-4. Checkout the last commit in Spring Boot 2.0
-   
-```
-cd spring-petclinic
-git checkout 9ecdc1111e3da388a750ace41a125287d9620534
-```
-5. Test you can build it
+5. Check out the last Spring Boot 2.0 commit:
 
 ```
-./gradlew build -x test
+git checkout 9ecdc1111e3da388a750ace41a125287d9620534
 ```
+
+6. Make sure it runs on your machine:
+
+```shell
+./gradlew build -x test
+``` 
 
 ## Migrate to Spring Boot 3 using the Moderne CLI
 
-1. Run the following command from the `spring-petclinic` repository
+1. Run the following command from the `spring-petclinic` repository:
 
-```
+```shell
 mod run --path . --recipeName org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_0 --recipeGAV org.openrewrite.recipe:rewrite-spring:4.36.0
 ```
 
-2. Apply the patch
+2. The previous command should have printed a path to a patch file in the
+   standard output. Let's take that patch file and apply it:
 
-The previous command should have printed a patch file in the standard output. To properly see the changes, let's apply them.
-
+```shell
+git apply PATCH_FILE_NAME
 ```
-git apply REPLACE_FOR_PATCH_FILE 
-```
 
-3. and then, see the changes with:
+3. You can then see the changes made by running:
 
-```
+```shell
 git diff
 ```
 
 ## Publish your OSS repositories to the Moderne platform
 
-Publishing LSTs into the platform allows to run multiple recipes without having to build the repository every single time. LSTs have 
-all the information required to run a recipe and therefore, it is not necessary to compile the source code. 
+Publishing your [Lossless Semantic
+Tree](https://docs.moderne.io/concepts/lossless-semantic-trees) (LST) artifacts
+to the platform allows you to run multiple recipes without having to build the
+repository every time (as LSTs contain all of the information needed to run a
+recipe).
 
+Let's walk through how to build and publish artifacts for your repository.
 
-1. In this case, we suggest you to publish multiple OSS repositories of your personal GitHub account or organization to really see the benefit 
-of running OpenRewrite at scale. 
+1. Clone your repository locally and run the `mod publish` command:
 
+```shell
+git clone YOUR_REPO
+mod publish --path PATH_TO_YOUR_REPO
 ```
-git clone REPLACE_WITH_MY_REPO_URL
-mod publish --path REPLACE_WITH_PATH_TO_MY_REPO
-```
 
-2. Now, after 2 minutes or so, you should be able to see it in the [Moderne Platform](https://public.moderne.io/). To check if the 
-repository has been added, go to https://public.moderne.io/organizations and search your repository name.
+2. After a few minutes, you should see it appear in the [Moderne
+   platform](https://public.moderne.io/). To check if the repository has been
+   added, go to
+   [https://public.moderne.io/organizations](https://public.moderne.io/organizations)
+   and search for your repository name.
 
-3. In case you want to run a recipe to your repository from the platform, we recommend to continue with the [Moderne Platform 
-Adventure](https://github.com/moderneinc/springboot-migration-workshop/tree/main/moderne-platform-adventure).
+3. If you want to run a recipe against your repository on the Moderne platform,
+   please continue to the [Moderne platform
+   Adventure](/moderne-platform-adventure/README.md).

--- a/moderne-platform-adventure/README.md
+++ b/moderne-platform-adventure/README.md
@@ -1,98 +1,113 @@
-# Moderne Platform Adventure
+# Moderne platform Adventure
 
-In this adventure, there are two challeges:
+In this adventure, you will utilize the [Moderne platform](https://public.moderne.io/) to:
 
-- The first one, which is all about migrating the spring-petclinic project from a UI 
-like we have completed in the other exercises. 
+* Migrate the [Spring
+  PetClinic](https://github.com/spring-projects/spring-petclinic) repository
+  from Spring Boot 2 to 3
+* Fix security vulnerabilities across hundreds of open-source projects
 
-- The second one is about fixing all the security vulnerabilities across hundreds of projects.
+## Prepare your environment
 
+Go to [https://public.moderne.io/](https://public.moderne.io/) and register with
+your GitHub account. Once you've signed in, you'll find more than 30,000
+open-source repositories that can be used to test OpenRewrite recipes without
+you having to configure anything.
 
-## Prepare environment
+*Note: If you're interested in adding your own repository to the Moderne
+platform, please see the [CLI adventure](/moderne-cli-adventure/README.md)*
 
-Visit https://public.moderne.io/ and register yourself with your GitHub account. Moderne has more than 30k open source repositories loaded that can be used to test the OpenRewrite recipes without having to configure 
-anything in your build system. If you are interested to see how you can publish a new open source repository, we recommend to also play
-with  the Moderne CLI adventure.
+## Migrating to Spring Boot 3 with the Moderne platform
 
-## Spring Boot Migration using the Moderne Platform
-
-1. Now, we are going to create a repository group with one repository that contains the
-Spring Petclinic content when it was using a 2.x Spring Boot version. To do so,
-click on the `Create` option of the `Repository Groups` section.
+1. Once you're logged in to [Moderne](https://public.moderne.io/), the first
+   thing you'll want to do is to create a repository group with just the Spring
+   PetClinic repository in it. To do so, click on the `Default` group in the top
+   right-hand corner of your screen and select `Create` from the menu that
+   appears:
 
 ![context menu](assets/menu.png)
 
-2. A repository group is a list of repositories that are grouped under a name that it is
-only visible for your user. You can use any name for the repository group. We are going
-to call it `petclinic`. After giving a name, you need to select the repository 
-`github.com/timtebeek/spring-petclinic@2.0.0`. Then click on the `Save` option.   
+2. A repository group is a list of repositories that are grouped under a name
+that is only visible to you. You can use any name for the repository group. For
+this adventure, let's call it `petclinic`. After giving it a name, select
+`github.com/timtebeek/spring-petclinic@2.0.0` from the list of available
+repositories. To save this repository group, please press the `Save` button in
+the bottom right corner of your screen:
 
 ![repository-groups](assets/repository-groups.png)
 
-3. Now, you can go back, and in the `Marketplace` menu, you can click on `Java` and 
-then `Spring`, and finally select `Spring Boot 3.x`.
+3. With the repository group created, you can go to the [Moderne
+   Marketplace](https://public.moderne.io/marketplace). From there, click on
+   `Java`, then `Spring`, then `Spring Boot 3.x`, and finally select [Migrate to
+   Spring Boot 3.0](https://public.moderne.io/recipes/org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_0?):
 
 ![recipe](assets/springboot-recipe.png) 
 
-4. After that, check again that in the top menu, your new repository group is selected 
-(in our case `petclinic`)and the`DRY RUN` option says that there is 1 single repository.
-Notice that there is a GitHub icon on the right side, which enables you to find the 
-source code of the recipe, which are always open source. They are all OpenRewrite 
-recipes.
+4. After that, double-check that the repository group you created is selected by
+   looking at the top right-hand corner of the screen. It should say
+   `petclinic`. Likewise, above the `DRY RUN` button, you should see that the
+   recipe will run against `1` repository. If you want more details about the
+   recipe, you can click on the `More Details` link. From there, you can find
+   additional information such as a link to the source code for this recipe (all
+   of the recipes are OpenRewrite recipes).
 
-5. Click on `DRY RUN`.
+5. To begin running the recipe, click on the `DRY RUN` button.
 
-6. Then you will see a recipe running, and when it is completed, you can click on the repository
-name to see the results. 
+6. You will now be redirected to a page that shows all of the relevant recipe
+   run information. Once it's finished, you can click on the repository name to
+   see the results:
 
 ![results](assets/execution.png)
 
-7. It is important to see that the results contain:
+7. If you look at the results you should see that:
 
-  - The removal of `@Autowired`.
-  - The replacement of Junit 4 for JUnit 5.
-  - The replacement of `javax` for `jakarta`.
-  - It is migrated to Java 17 and uses text blocks.
-  - Some best practices are applied such as `public` test method modifiers.
- 
+  * `@Autowired` was removed
+  * JUnit 4 has been replaced with JUnit 5
+  * `javax` has been replaced with `jakarata`
+  * The code has been migrated to Java 17 and text blocks are used
+  * Some best practices are applied (such as adding the `public` test method modifier)
 
-## Security Vulnerabilities using the Moderne Platform
+## Fixing security vulnerabilities with the Moderne platform
 
-Another use case to use the platform is for detecting CVEs in the dependencies
-and upgrade a set of repositories with the last versions. Since the Moderne platform
-supports complex refactorings such as the SpringBoot 3 migration, it is expected
-that the community can contribute and provide recipe for other major migrations that
-not only require to bump the dependency version. In this challenge, we are going to see
-how we can see the list of vulnerabilities in important open source repositories and
-create a composite refactor with many the minor vulnerabilities that we want to fix.
+Another substantial use case for the Moderne platform is detecting and
+potentially resolving CVEs in your projects and their dependencies. Since the
+Moderne platform supports complex refactoring recipes (such as the Spring Boot 3
+migration), the community can contribute and provide recipes for other major
+migrations that do more than bump a dependency version.
 
-1. In this case, we are going to use the `Check for dependency vulnerabilities` recipe.
-This recipe offers three options. For demo purposes, we recommend to simply 
-select:
+In this part of the adventure, let's use the Moderne platform to get a list of
+vulnerabilities in open-source repositories. 
 
-    - Scope:  `compile`. 
-    - Overwrite management version: true.
-    - Add markers: No value selected.
+1. Begin by navigating to the [Check for dependency vulnerabilities
+   recipe](https://public.moderne.io/recipes/org.openrewrite.java.dependencies.DependencyVulnerabilityCheck
+   ).
+  
+2. Select `compile` for the first option (`scope`), `true`, for the second
+   option (`override managed version`), and leave the third option as blank
+   (`add markers`).
 
-2. In the top menu, select the default repository group, which is composed by a hundred (142) of
-open source Netflix and Spring repositories.
+3. Click on the repository group link in the top right-hand corner of the screen
+   and select `Default` as the group to run on.
 
-3. Select `DRY RUN`, this should take 10 minutes approx. Now, clicking on each of the repositories, 
-you should be able to see what dependency changes are required to remove vulnerabilities, in 
-case dependencies can be locally fixed.
+4. Click on the `DRY RUN` button to begin executing this recipe. It should take
+   a few minutes to run.
 
-4. Click on data tables (right side blue button) and download the vulnerability report in CSV format.
+5. Once the recipe is done running, you can click on the individual repositories
+   to see suggested changes that fix some vulnerabilities. You can also click on
+   the `Data Tables` button to get taken to a page that allows you to download a
+   CSV that contains a list of CVEs that the repositories are
+   vulnerable to. Download the CSV vulnerability report.
 
-5. Open the CSV with Google spreadsheets or your preferred tool.You will see that the CSV contains
-an entry per vulnerability, depedency and repository. There is an interesting column called
-`fixedVersion`, which tells you what is the immediate version that fixes the vulnerability. It
-is also important to notice that there is a `depth` column because we also analyze transitive
-dependencies.
-
+6. Open the CSV with your preferred CSV reader. You will see that the CSV
+   contains an entry per vulnerability, dependency, and repository. Take special
+   note of the column called `fixedVersion`. That tells you what version fixes
+   that vulnerability. Also take note of the `depth` column, which lets you see
+   how many dependencies away it is from your original dependency.
    
-## Misk
+## Relevant links
 
-- [Moderne Platform documentation](https://docs.moderne.io/)
+* [Moderne platform documentation](https://docs.moderne.io/)
+* [OpenRewrite documentation](https://docs.openrewrite.org/)
 
 
 

--- a/spring-boot-migrator-adventure/README.md
+++ b/spring-boot-migrator-adventure/README.md
@@ -1,73 +1,72 @@
 # Spring Boot Migrator Adventure
 
-Spring Boot Migrator(SBM) offers a CLI to run recipes to migrate or upgrade 
-a given application to Spring Boot 3. For developing new and custom recipes, SBM 
-provides an opinionated API compatible with OpenRewrite recipes and a set of 
-specialized resource representations to simplify recipe development for 
-Spring Boot.
+The Spring Boot Migrator (SBM) is a CLI tool that automates code migrations to
+upgrade or migrate to Spring Boot 3. It offers an opinionated API that is compatible
+with OpenRewrite recipes as well as a specialized resource representation to
+simplify recipe development for Spring Boot.
 
-*IMPORTANT: This is a very experimental project and not
-our recommended way to migrate to Spring Boot 3. The project has not created more
-releases since 2022 and there are important reported bugs that need to be fixed to 
-propertly run in any repository. However, the goal of this workshop is to show
-what are the current available alternatives to migrate to Spring Boot 3 and enable
-you to decide by your own.* 
+**Warning**: This is a very experimental project and not our recommended way of
+migrating to Spring Boot 3. The project has not created any more releases since
+2022 and there are substantial bugs that need to be fixed for it to run properly
+in any repository. With that being said, we wanted to show what alternatives
+exist so that you can make the decision that best meets your own needs.
 
 ## Prepare your environment
 
-1.  Download the spring-boot-upgrade.jar
+1.  Download the `spring-boot-upgrade.jar`:
 
-```
+```shell
 wget https://github.com/spring-projects-experimental/spring-boot-migrator/releases/latest/download/spring-boot-upgrade.jar
 ```
 
-1. Clone the repository `https://github.com/spring-projects/spring-petclinic`
+2. Clone the [Spring PetClinic](https://github.com/spring-projects/spring-petclinic) repository
 
-```
+```shell
 git clone https://github.com/spring-projects/spring-petclinic
 ```
 
-2. Checkout the last commit in Spring Boot 2.0
+3. Check out the last Spring Boot 2.0 commit:
 
-```
-cd spring-petclinic
+```shell
 git checkout 9ecdc1111e3da388a750ace41a125287d9620534
 ```
-3. Test you can build it
 
-```
+4. Make sure it runs on your machine:
+
+```shell
 ./mvnw package -DskipTests
 ``` 
 
-4. Validate that you are running with Java 17`. SBM fails when it is tested with Java 19.
+5. Make sure that you are using Java 17. We've found that SBM does not work with
+  Java 19.
 
-```
+```shell
 java -version
 ```
 
 ## Run the SBM
 
-1. Run SBM
+1. To run the SBM, navigate to your Spring PetClinic repository and execute this
+   command:
 
-```
+```shell
 java -jar ../spring-boot-upgrade.jar .
 ```
 
-2. Open http://localhost:8080/spring-boot-upgrade with your browser and follow the instructions. The instructions will list you a list of 
-mandatory recipes and others that are optional depending on your preferences. 
+2. Open
+   [http://localhost:8080/spring-boot-upgrade](http://localhost:8080/spring-boot-upgrade)
+   with your browser and follow the instructions on that page. You will find a
+   list of mandatory recipes and other optional ones that you can select
+   depending on your preferences. 
 
-Notice that there are GitHub issues listed in some of the listed 
-recipes. To see what have changed by each recipe, you need to check what commits have been introduced with your Git user in the repository.
+3. Note that there are GitHub issues listed in some of the recipes. To see what
+  has changed for each recipe, you need to check what commits have been
+  introduced from your Git user in the repository. To do so, run `git log` and
+  look for commits starting with `SBM: `.
 
-3. Simply run `git log` and detect the commits that starts with `SBM:`.
+4. This should print you a list of commits like:
 
-```
-git log
-```
-
-This should print you a list of commits like:
-
-```
+```shell
 commit dd308045cff42f384a51c42428030eaeaa5185f3 (HEAD -> boot-3-upgrade-demo)
 Author: rpau <raquel@moderne.io>
 Date:   Fri May 12 12:32:26 2023 +0200
@@ -105,11 +104,12 @@ Date:   Fri May 12 12:30:37 2023 +0200
     SBM: applied recipe 'sbu30-upgrade-dependencies'
 ```
  
-To understand the code changes of each change, you can use the `git show $SHA` command. What is rellevant from
-this execution, is that the codechanges are different than running the last version of `rewrite-spring` using
-the Moderne CLI, Gradle or Maven. For instance, this patch is not included:
+5. To understand the code changes for each commit, you can use the `git show $SHA`
+command. Please note that these code changes will be different than what you'd
+get from the other adventures in this workshop. For instance, this patch is not
+included with SBM: 
 
-```
+```shell
 --- a/src/main/java/org/springframework/samples/petclinic/model/BaseEntity.java
 +++ b/src/main/java/org/springframework/samples/petclinic/model/BaseEntity.java
 @@ -17,10 +17,10 @@ package org.springframework.samples.petclinic.model;
@@ -126,6 +126,6 @@ the Moderne CLI, Gradle or Maven. For instance, this patch is not included:
 +import jakarta.persistence.MappedSuperclass;
 ```
 
-The reason is that this project is still experimental and has not been 
-recently updated while the SpringBoot 3 recipe has been evolved. 
-
+The reason for these differences is largely due to the fact that this project
+has not been recently updated, whereas the Spring Boot 3 recipe has evolved over
+time.

--- a/spring-tools-adventure/README.md
+++ b/spring-tools-adventure/README.md
@@ -6,49 +6,48 @@ Visual Studio.
 
 ## Prepare your environment
 
-- Install Visual Studio Code.
-- Install Spring Tools 4 plugin from https://spring.io/tools
-- Clone the Spring Petclinic repository, which is an Spring Boot
-application example for demo purposes:
+1. Install [Visual Studio Code](https://code.visualstudio.com/)
 
-```
+2. Install the [Spring Tools 4 plugin](https://spring.io/tools)
+
+3. Clone the [Spring PetClinic
+   repository](https://github.com/spring-projects/spring-petclinic):
+
+```shell
 git clone https://github.com/spring-projects/spring-petclinic
 ```
 
-Now, let's come back to the past where Spring 2.7 was used.
+4. Check out the last Spring Boot 2.0 commit:
 
-```
+```shell
 git checkout 9ecdc1111e3da388a750ace41a125287d9620534
 ```
 
 ## Migrate to Spring Boot 3 using Spring Tools 4 
 
-Spring Tools 4 embeds OpenRewrite, and from Visual Studio, there is 
-a limited number of OpenRewrite migrations that can be applied. This
-is a very recent feature that it is only available for Maven projects.
+Spring Tools 4 has OpenRewrite embedded into it. From VS Code, you can open the
+`pom.xml` file and right-click anywhere in the file. You should see two
+important options appear:
 
-To see the list of refactors available, you need to open the `pom.xml`
-file. You will see two important options:
-
-- Refactor Spring Boot project
-- Upgrade Spring Boot version  
+* Refactor Spring Boot Project
+* Upgrade Spring Boot Version
 
 ![Visual Studio Dialog](context-menu-options.png)
 
-In this exercise, we will select `Upgrade Spring Boot Version`, then the
-following dialog should appear:
+For this adventure, let's click on `Upgrade Spring Boot Version`. The following
+dialog window should then appear: 
 
 ![Migration options](migration-options.png)
 
-Select `Migrate to Spring Boot 3.0`. Then a progress message will appear at 
-the very bottom of Visual Studio Code. After the process finishes, the changes
-has not been yet saved into disk and you might perceive that there are just few
-changes applied.
+Select `Migrate to Spring Boot 3.0`. A progress message should appear at the
+bottom of VS Code. After the process finishes, the changes won't be saved yet.
+You'll need to click on `File` > `Save All` to save all of the files and preview
+the changes in Git:
 
-Click on `File` > `Save All` and then you can easily preview the changes
-in Git. 
-
-```
+```shell
 git diff
 ```
 
+**Note:** This is a very recent feature that is only available for Maven
+projects. Only some of the OpenRewrite migrations can be applied with this
+feature.


### PR DESCRIPTION
My goal with this original pass through of the READMEs is to:

* Fix a variety of grammatical and spelling mistakes
* Improve the readibility of various sections
* Ensure links work correctly
* Make the adventures more consistent with one another

There are still many issues that I didn't address. For instance, some of the adventures did not work for me when I ran through them and some of the instructions linked to things that didn't appear to exist. Furthermore, I didn't do as many editing pass throughs as I normally would due to time so there may still be some mistakes.

I also didn't improve the steps themselves to break things down further. More work will be needed in the future, but I wanted to save these changes for now.