### PR TITLE
Adding README details

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ repository to Spring Boot 3.
 To complete our adventures, you will need:
 
 * Some basic Spring and Git knowledge
-* To be familiar with Java 8 and Java 17
+* Having Java 8 and Java 17 installed
 * A GitHub account
 * An IDE of your choice (although we recommend using [Visual Studio Code](https://code.visualstudio.com/) for the Spring Tools Adventure)
 

--- a/gradle-plugin-adventure/README.md
+++ b/gradle-plugin-adventure/README.md
@@ -62,8 +62,14 @@ here](https://docs.openrewrite.org/running-recipes/running-rewrite-on-a-gradle-p
 ./gradlew --info --init-script init.gradle rewriteRun
 ```
 
-3. You can then review the changes by running `git diff`. 
+3. You can then review the changes by running `git diff`. If you look at the results you should see that:
 
+  * The `@Autowired` annotation was removed
+  * JUnit 4 has been replaced with JUnit 5
+  * `javax` has been replaced with `jakarta`
+  * The code has been migrated to Java 17 and text blocks are used
+  * Some best practices are applied (such as adding the `public` test method modifier)
+   
 ## (Optional) Fix Static Code Analysis Issues
 
 If you have time, we recommend trying out one of the most important recipes in

--- a/moderne-cli-adventure/README.md
+++ b/moderne-cli-adventure/README.md
@@ -1,4 +1,4 @@
-# Moderne CLI adventure Adventure
+# Moderne CLI Adventure
 
 In this adventure, you will use the [Moderne
 CLI](https://docs.moderne.io/moderne-cli/cli-intro), a free tool that allows

--- a/moderne-platform-adventure/README.md
+++ b/moderne-platform-adventure/README.md
@@ -61,9 +61,9 @@ the bottom right corner of your screen:
 
 7. If you look at the results you should see that:
 
-  * `@Autowired` was removed
+  * The `@Autowired` annotation was removed
   * JUnit 4 has been replaced with JUnit 5
-  * `javax` has been replaced with `jakarata`
+  * `javax` has been replaced with `jakarta`
   * The code has been migrated to Java 17 and text blocks are used
   * Some best practices are applied (such as adding the `public` test method modifier)
 

--- a/spring-tools-adventure/README.md
+++ b/spring-tools-adventure/README.md
@@ -25,7 +25,13 @@ git checkout 9ecdc1111e3da388a750ace41a125287d9620534
 
 ## Migrate to Spring Boot 3 using Spring Tools 4 
 
-Spring Tools 4 has OpenRewrite embedded into it. From VS Code, you can open the
+Spring Tools 4 has OpenRewrite embedded into it. 
+
+Open the spring-petclinic repository with visual studio. You'll need to
+click on `File` > `Open Folder` and select the folder where you have 
+downloaed the Spring Petclinic repository. 
+
+From VS Code, you can open the
 `pom.xml` file and right-click anywhere in the file. You should see two
 important options appear:
 
@@ -51,3 +57,12 @@ git diff
 **Note:** This is a very recent feature that is only available for Maven
 projects. Only some of the OpenRewrite migrations can be applied with this
 feature.
+
+However, if you look at the results you should see that:
+
+  * The `@Autowired` annotation was removed
+  * JUnit 4 has been replaced with JUnit 5
+  * `javax` has been replaced with `jakarta`
+  * The code has been migrated to Java 17 and text blocks are used
+  * Some best practices are applied (such as adding the `public` test method modifier)
+   


### PR DESCRIPTION
Fixes small issues introduced in the previous commit and explains the main differences that users should be able to see after running the SpringBoot 3 migration.